### PR TITLE
Updated deps to support node 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "test": "mocha test.js"
   },
   "devDependencies": {
-    "mocha": "^1.20.1",
-    "rimraf": "^2.3.2",
-    "should": "^6.0.1"
+    "mocha": "^2.2.5",
+    "rimraf": "^2.4.2",
+    "should": "^7.0.2"
   },
   "keywords": [
     "sqlite sqlite3 json"
   ],
   "dependencies": {
-    "commander": "^2.8.0",
-    "mkdirp": "^0.5.0",
-    "sqlite3": "^2.2.4"
+    "commander": "^2.8.1",
+    "mkdirp": "^0.5.1",
+    "sqlite3": "^3.0.9"
   }
 }


### PR DESCRIPTION
Updated all deps to latest versions.

The only important thing here is `sqlite3@3.x`, because `sqlite3@2.x` doesn't support node `0.12.x`.